### PR TITLE
update `app.getName()` -> `app.name`

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -59,7 +59,8 @@ process.on('message', msg => {
 });
 
 process.on('uncaughtException', err => {
-  const { name } = electron.app;
+  const { app } = electron.app;
+  const name = app.name || app.getName();
 
   const onHandled = () => {
     electron.dialog.showErrorBox(`${name} encountered an error`, err.stack);

--- a/src/hook.js
+++ b/src/hook.js
@@ -59,7 +59,7 @@ process.on('message', msg => {
 });
 
 process.on('uncaughtException', err => {
-  const name = electron.app.getName();
+  const { name } = electron.app;
 
   const onHandled = () => {
     electron.dialog.showErrorBox(`${name} encountered an error`, err.stack);

--- a/src/hook.js
+++ b/src/hook.js
@@ -59,8 +59,9 @@ process.on('message', msg => {
 });
 
 process.on('uncaughtException', err => {
-  const { app } = electron.app;
-  const name = app.name || app.getName();
+  const name = 'name' in electron.app ? electron.app.name :
+    'getName' in electron.app ? electron.app.getName() :
+      'the application';
 
   const onHandled = () => {
     electron.dialog.showErrorBox(`${name} encountered an error`, err.stack);


### PR DESCRIPTION
Closes #34.

The [`app.getName()` API](https://www.electronjs.org/docs/api/app#appgetname) and its counterpart `app.setName()` were deprecated some time ago.