### PR TITLE
linux testing will run on ubuntu 22.04 (instead of latest, which I _think_ is 24.04 now?)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,40 +12,40 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-22.04]
         node: [20, 18]
         electron: [30, 28, 23]
         exclude:
           # there's an issue with signals in retry-cli on linux in node 20 🤷‍♀️
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node: 20
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node: 16
             electron: 20
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node: 16
             electron: 18
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node: 16
             electron: 16
           - os: windows-latest
             node: 14
             electron: 14
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node: 14
             electron: 12
           - os: windows-latest
             node: 12
             electron: 10
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             node: 10
             electron: 8
     runs-on: ${{ matrix.os }}
     name: test (${{matrix.os}}, node@${{matrix.node}}, electron@${{matrix.electron}})
     steps:
       - uses: actions/checkout@v3
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
+      - if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: sudo apt-get install xvfb
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This is the version that was used at the last change to this lib. It seems that all builds fail on `ubuntu-latest` now, without any change to the lib itself -- so the OS is at fault rather than the library. There will be a separate task to debug and upgrade the build agent as necessary